### PR TITLE
docs: fix .github directory typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Laravel Dev Kit is a starter kit for Laravel applications, designed to save time
 
 ```plaintext
 /
-|-- .gitHub
+|-- .github
 |   |-- workflows
 |   |   |-- auto-merge-dependabot.yml
 |   |   |-- code-quality.yml.yml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the directory name in the README file structure section from `.gitHub` to `.github` to accurately reflect the standard naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->